### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,36 @@
+name: Build Windows
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone FLTK
+        run: git clone https://github.com/fltk/fltk.git --branch release-1.4.4 --depth 1
+
+      - name: Build FLTK
+        shell: cmd
+        run: |
+          cd fltk
+          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -D CMAKE_BUILD_TYPE=Release -D FLTK_MSVC_RUNTIME_DLL=off
+          cmake --build build --config Release
+
+      - name: Configure Tablecruncher
+        shell: cmd
+        run: |
+          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -D CMAKE_BUILD_TYPE=Release -DFLTKINCDIR=%GITHUB_WORKSPACE%\fltk -DFLTKLIBDIR=%GITHUB_WORKSPACE%\fltk\build
+
+      - name: Build Tablecruncher
+        shell: cmd
+        run: cmake --build build --config Release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tablecruncher-windows
+          path: build/dist


### PR DESCRIPTION
## Summary
- build FLTK 1.4.4 from source and compile Tablecruncher on Windows
- upload Windows build artifacts from dist directory

## Testing
- `yamllint .github/workflows/windows-build.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3775853988321a8c96d156a892bc3
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add GitHub Actions workflow to build and upload Windows artifacts for Tablecruncher.
> 
>   - **Workflow**:
>     - Adds `.github/workflows/windows-build.yml` to build Tablecruncher on Windows.
>     - Triggers on push and workflow dispatch.
>   - **Build Process**:
>     - Clones FLTK 1.4.4 and builds it using CMake with Visual Studio 17 2022.
>     - Configures and builds Tablecruncher using CMake with FLTK paths.
>   - **Artifacts**:
>     - Uploads build artifacts from `build/dist` as `tablecruncher-windows`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Ftablecruncher&utm_source=github&utm_medium=referral)<sup> for f5f61f3db98d870467513b9a0005a1eda5e9ae7f. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->