### PR TITLE
Add macOS build workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,38 @@
+name: Build macOS
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone FLTK
+        run: git clone https://github.com/fltk/fltk.git --branch release-1.4.4 --depth 1
+
+      - name: Build FLTK
+        run: |
+          cd fltk
+          export MIN_MAC_VERSION=10.15
+          ./configure CFLAGS="-mmacosx-version-min=$MIN_MAC_VERSION" CXXFLAGS="-mmacosx-version-min=$MIN_MAC_VERSION" LDFLAGS="-mmacosx-version-min=$MIN_MAC_VERSION" --enable-localzlib
+          make -j$(sysctl -n hw.ncpu)
+
+      - name: Configure Tablecruncher
+        run: |
+          export MIN_MAC_VERSION=10.15
+          cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DFLTKDIR=$GITHUB_WORKSPACE/fltk -DMACOS_VERSION=$MIN_MAC_VERSION
+
+      - name: Build Tablecruncher
+        run: cmake --build build --config Release -- -j$(sysctl -n hw.ncpu)
+
+      - name: Create bundle
+        run: cmake --build build --config Release --target create_bundle -- -j$(sysctl -n hw.ncpu)
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tablecruncher-macos
+          path: build/dist

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -11,19 +11,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clone FLTK
-        run: git clone https://github.com/fltk/fltk.git --branch release-1.4.4 --depth 1
+        run: |
+          git clone https://github.com/fltk/fltk.git
+          cd fltk
+          git checkout release-1.4.4
 
       - name: Build FLTK
         run: |
           cd fltk
-          export MIN_MAC_VERSION=10.15
-          ./configure CFLAGS="-mmacosx-version-min=$MIN_MAC_VERSION" CXXFLAGS="-mmacosx-version-min=$MIN_MAC_VERSION" LDFLAGS="-mmacosx-version-min=$MIN_MAC_VERSION" --enable-localzlib
-          make -j$(sysctl -n hw.ncpu)
+          cmake -S . -B build -DOPTION_BUILD_SHARED_LIBS=OFF -DFLTK_BUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
+          cmake --build build --parallel $(sysctl -n hw.ncpu)
+          cmake --install build --prefix $GITHUB_WORKSPACE/fltk-install
 
       - name: Configure Tablecruncher
         run: |
           export MIN_MAC_VERSION=10.15
-          cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DFLTKDIR=$GITHUB_WORKSPACE/fltk -DMACOS_VERSION=$MIN_MAC_VERSION
+          cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DFLTKDIR=$GITHUB_WORKSPACE/fltk-install -DMACOS_VERSION=$MIN_MAC_VERSION
 
       - name: Build Tablecruncher
         run: cmake --build build --config Release -- -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -26,7 +26,11 @@ jobs:
       - name: Configure Tablecruncher
         run: |
           export MIN_MAC_VERSION=10.15
-          cmake -S . -B build -D CMAKE_BUILD_TYPE=Release -DFLTKDIR=$GITHUB_WORKSPACE/fltk-install -DMACOS_VERSION=$MIN_MAC_VERSION
+          cmake -S . -B build \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D FLTKINCDIR=$GITHUB_WORKSPACE/fltk-install/include \
+            -D FLTKLIBDIR=$GITHUB_WORKSPACE/fltk-install \
+            -D MACOS_VERSION=$MIN_MAC_VERSION
 
       - name: Build Tablecruncher
         run: cmake --build build --config Release -- -j$(sysctl -n hw.ncpu)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Tablecruncher on macOS, building FLTK 1.4.4 from source and bundling the app

## Testing
- `cmake -S . -B build` *(fails: Please set either FLTKINCDIR or FLTKDIR)*

------
https://chatgpt.com/codex/tasks/task_e_68b380b8e0388321ad50707e1e1c4a33
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add GitHub Actions workflow to build and bundle Tablecruncher on macOS, including FLTK build and artifact upload.
> 
>   - **Workflow**:
>     - Adds `.github/workflows/macos-build.yml` for macOS build using GitHub Actions.
>     - Triggers on push and manual dispatch.
>   - **Build Process**:
>     - Clones FLTK 1.4.4 from GitHub and builds it from source.
>     - Configures Tablecruncher with FLTK paths and builds it.
>     - Creates a macOS app bundle.
>   - **Artifact**:
>     - Uploads the built Tablecruncher app as an artifact named `tablecruncher-macos`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Ftablecruncher&utm_source=github&utm_medium=referral)<sup> for 6be03986fb00ae823b2fdcf36f891c7f9caaedfb. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->