### PR TITLE
Add Debian packaging support

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -35,8 +35,17 @@ jobs:
       - name: Build Tablecruncher
         run: cmake --build build -- -j$(nproc)
 
-      - name: Upload artifact
+      - name: Package Debian
+        run: bash scripts/build_deb.sh
+
+      - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: tablecruncher-linux
           path: build/dist
+
+      - name: Upload Debian package
+        uses: actions/upload-artifact@v4
+        with:
+          name: tablecruncher-deb
+          path: Tablecruncher_v*_Linux_x86_64.deb

--- a/BUILD.md
+++ b/BUILD.md
@@ -109,4 +109,13 @@ Use `VS Studio C++` to build the application. Or use `cmake` in a "Developer Com
     cd ../scripts/
     ./build_appimage.sh
 
+## Build Debian package
+
+    cd build/
+    rm -rf *
+    cmake -DFLTKDIR="/home/sf/Documents/Builds/fltk-1.4.3" ..
+    cmake --build . -- -j$(nproc)
+    cd ../scripts/
+    ./build_deb.sh
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ endif()
 
 if(LINUX)
     # Install binary
-    install(TARGETS tablecruncher RUNTIME DESTINATION bin)
+    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 
     # Desktop entry
     install(FILES assets/linux/tablecruncher.desktop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ endif()
 
 
 
-if(FALSE)
+if(LINUX)
     # Install binary
     install(TARGETS tablecruncher RUNTIME DESTINATION bin)
 
@@ -192,7 +192,7 @@ if(FALSE)
     install(FILES assets/linux/tablecruncher.desktop
         DESTINATION share/applications)
 
-    # App icon
+    # App icons
     install(FILES assets/linux/icons/64x64/tablecruncher.png
         DESTINATION share/icons/hicolor/64x64/apps)
 
@@ -201,6 +201,18 @@ if(FALSE)
 
     install(FILES assets/linux/icons/256x256/tablecruncher.png
         DESTINATION share/icons/hicolor/256x256/apps)
+
+    # CPack configuration for Debian package
+    set(CPACK_PACKAGE_NAME "tablecruncher")
+    set(CPACK_PACKAGE_VERSION "${APP_VERSION}")
+    set(CPACK_PACKAGE_CONTACT "Tablecruncher")
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Tablecruncher")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fast CSV viewer and editor")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+    set(CPACK_GENERATOR "DEB")
+    include(CPack)
 endif()
 
 

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="$ROOT_DIR/build"
+VERSION_FILE="$SCRIPT_DIR/version.txt"
+
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "version.txt not found!"
+  exit 1
+fi
+VERSION=$(tr -d '[:space:]' < "$VERSION_FILE")
+
+cd "$BUILD_DIR"
+
+cpack -G DEB
+DEB_FILE=$(ls *.deb | head -n 1)
+OUTPUT="$ROOT_DIR/Tablecruncher_v${VERSION}_Linux_x86_64.deb"
+mv "$DEB_FILE" "$OUTPUT"
+echo "Created $OUTPUT"


### PR DESCRIPTION
## Summary
- add CPack configuration and install rules to build a Debian package
- provide `build_deb.sh` helper script
- document how to create a `.deb` in BUILD.md

## Testing
- `bash scripts/build_deb.sh` *(fails: CPack project name not specified)*
- `mkdir -p build && cd build && cmake ..` *(fails: Please set either FLTKINCDIR or FLTKDIR.)*

------
https://chatgpt.com/codex/tasks/task_e_68b38984bf208321b8ff9c41f006f30f
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add Debian packaging support with CPack configuration, a build script, CI updates, and documentation.
> 
>   - **Debian Packaging**:
>     - Add CPack configuration in `CMakeLists.txt` for Debian package creation.
>     - New script `scripts/build_deb.sh` to automate Debian package building.
>   - **CI/CD**:
>     - Update `.github/workflows/linux-build.yml` to include Debian package build and upload steps.
>   - **Documentation**:
>     - Update `BUILD.md` with instructions for building a Debian package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Ftablecruncher&utm_source=github&utm_medium=referral)<sup> for 68bd36e7f63d671e0da89f3a68e6895c8103f046. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->