### PR TITLE
Fix Debian packaging target

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -35,8 +35,17 @@ jobs:
       - name: Build Tablecruncher
         run: cmake --build build -- -j$(nproc)
 
-      - name: Upload artifact
+      - name: Package Debian
+        run: bash scripts/build_deb.sh
+
+      - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: tablecruncher-linux
           path: build/dist
+
+      - name: Upload Debian package
+        uses: actions/upload-artifact@v4
+        with:
+          name: tablecruncher-deb
+          path: Tablecruncher_v*_Linux_x86_64.deb

--- a/BUILD.md
+++ b/BUILD.md
@@ -109,4 +109,13 @@ Use `VS Studio C++` to build the application. Or use `cmake` in a "Developer Com
     cd ../scripts/
     ./build_appimage.sh
 
+## Build Debian package
+
+    cd build/
+    rm -rf *
+    cmake -DFLTKDIR="/home/sf/Documents/Builds/fltk-1.4.3" ..
+    cmake --build . -- -j$(nproc)
+    cd ../scripts/
+    ./build_deb.sh
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if(UNIX AND NOT APPLE)
-    set(LINUX TRUE)
-endif()
+# Platform detection helpers
+# CMake does not define a built-in `LINUX` variable. Use the standard
+# `UNIX` and `APPLE` checks directly for GNU/Linux specific logic.
 
 string(TIMESTAMP NOW "%Y-%m-%dT%H:%M")
 string(TIMESTAMP TODAY "%Y-%m-%d")
@@ -83,7 +83,7 @@ elseif(APPLE)
     endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -DMY_VERSION=\\\"${APP_VERSION}\\\" -DMY_YEAR=\\\"${YEAR}\\\" -DMY_TODAY=\\\"${TODAY}\\\" -DMY_NOW=\\\"${NOW}\\\" -mmacosx-version-min=${MACOS_VERSION} -D_THREAD_SAFE -D_REENTRANT")
     set(CMAKE_C_FLAGS "-mmacosx-version-min=${MACOS_VERSION}")
-elseif(LINUX)
+elseif(UNIX AND NOT APPLE)
     set(PLATFORM "Linux")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -DMY_VERSION=\\\"${APP_VERSION}\\\" -DMY_YEAR=\\\"${YEAR}\\\" -DMY_TODAY=\\\"${TODAY}\\\" -DMY_NOW=\\\"${NOW}\\\" -D_THREAD_SAFE -D_REENTRANT")
     if(APPIMAGE STREQUAL "1")
@@ -143,7 +143,7 @@ elseif(WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE fltk::fltk fltk::images fltk::z)
     target_link_options(${PROJECT_NAME} PRIVATE ${LINKER_FLAGS})
     target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
-elseif(LINUX)
+elseif(UNIX AND NOT APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE
         ${FLTKLIBDIR}/lib/libfltk.a
         ${FLTKLIBDIR}/lib/libfltk_images.a
@@ -184,15 +184,15 @@ endif()
 
 
 
-if(FALSE)
+if(UNIX AND NOT APPLE)
     # Install binary
-    install(TARGETS tablecruncher RUNTIME DESTINATION bin)
+    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 
     # Desktop entry
     install(FILES assets/linux/tablecruncher.desktop
         DESTINATION share/applications)
 
-    # App icon
+    # App icons
     install(FILES assets/linux/icons/64x64/tablecruncher.png
         DESTINATION share/icons/hicolor/64x64/apps)
 
@@ -201,6 +201,18 @@ if(FALSE)
 
     install(FILES assets/linux/icons/256x256/tablecruncher.png
         DESTINATION share/icons/hicolor/256x256/apps)
+
+    # CPack configuration for Debian package
+    set(CPACK_PACKAGE_NAME "tablecruncher")
+    set(CPACK_PACKAGE_VERSION "${APP_VERSION}")
+    set(CPACK_PACKAGE_CONTACT "Tablecruncher")
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Tablecruncher")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fast CSV viewer and editor")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+    set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+    set(CPACK_GENERATOR "DEB")
+    include(CPack)
 endif()
 
 

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="$ROOT_DIR/build"
+VERSION_FILE="$SCRIPT_DIR/version.txt"
+
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "version.txt not found!"
+  exit 1
+fi
+VERSION=$(tr -d '[:space:]' < "$VERSION_FILE")
+
+cd "$BUILD_DIR"
+
+cpack -G DEB
+DEB_FILE=$(ls *.deb | head -n 1)
+OUTPUT="$ROOT_DIR/Tablecruncher_v${VERSION}_Linux_x86_64.deb"
+mv "$DEB_FILE" "$OUTPUT"
+echo "Created $OUTPUT"


### PR DESCRIPTION
## Summary
- use standard `UNIX AND NOT APPLE` check for Linux packaging and install blocks

## Testing
- `cmake -S . -B build -DFLTKDIR=/workspace/fltk -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build` *(fails: FL/Fl.H: No such file or directory)*
- `bash scripts/build_deb.sh` *(fails: install command returned error)*

------
https://chatgpt.com/codex/tasks/task_e_68b38984bf208321b8ff9c41f006f30f
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Debian packaging by using standard UNIX checks and adds Debian packaging steps in CMake and GitHub Actions.
> 
>   - **CMakeLists.txt**:
>     - Replaces `LINUX` variable with `UNIX AND NOT APPLE` for platform-specific logic.
>     - Adds CPack configuration for Debian package creation.
>   - **GitHub Actions** (`linux-build.yml`):
>     - Adds a step to package Debian using `scripts/build_deb.sh`.
>     - Uploads Debian package as an artifact.
>   - **Documentation** (`BUILD.md`):
>     - Adds instructions for building Debian package.
>   - **Scripts** (`build_deb.sh`):
>     - New script to create Debian package using CPack.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Ftablecruncher&utm_source=github&utm_medium=referral)<sup> for 84975e73cd65b5791710e591f098f9e16d53d761. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->